### PR TITLE
gts2-common: switch gnss from passthrough to hwbinder to avoid marsha…

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -85,7 +85,7 @@
     </hal>
     <hal format="hidl">
         <name>android.hardware.gnss</name>
-        <transport arch="32">passthrough</transport>
+        <transport>hwbinder</transport>
         <version>1.0</version>
         <interface>
             <name>IGnss</name>


### PR DESCRIPTION
…l_agps_ril_request_setid gnss crash

When using gnss passthrough, we get the following crash message on multiple S2 tab devices including T710,
T810, T815, etc on a daily basis (< 24 hours).

By switching to hwbinder, the same users who were experiencing daily crashes can now go +100 hours with no crashes.

However, in order for gnss hwbinder to work, both passthrough and hwbinder must be specified in device.mk otherwise
tablet will get stuck at boot animation complaining that it cannot find gnss passthrough implementation.  The gnss
hwbinder is specified in the manifest.xml file.

Thus it appears that the proprietary gps.default.so blob does not work correctly in passthrough mode with 17.1
and luckily hwbinder works.

We found out gnss was the culprit because I started a XDA thread at

https://forum.xda-developers.com/t/troubleshooting-random-reboot-problems-on-s2-exynos5433-tablet-only-discussion-for-users-running-any-version-of-android-10.4308203/

and 4 users shared their adb logs and tombstones and most of them pointed to the same gnss crash message below.
Some people also reported that overnight their device would reboot itself and end up in TWRP mode.
We found that through TWRP logs, that Android 8+ rescue party was being activated.

According to

https://source.android.com/devices/tech/debug/rescue-party

"Rescue Party receives information about boot and crash events and starts if:

The system_server restarts more than 5 times in 5 minutes.
A persistent system app crashes more than 5 times in 30 seconds."

So if gnss crashes 5 times in less than 5 minutes, that's why some people had TWRP loaded overnight and if TWRP
doesn't implement deep sleep then people were also facing dead battery issues in the morning. Unfortunately,
we don't have any logs proving that gnss crashes is what triggered the rescue party. It could be something
else, but we are limited to what users will share with their logs.

Huge thanks to XDA users lpedia, CuckooPenguin and Yogi555
for testing the various gnss patches until we finally figured out the hwbinder solution.

In addition, huge thanks to Anan Jaser for providing hints, code and acting as a sounding board while we figured this out.

=== gnss crash log ===

LineageOS Version: '17.1-20210718-UNOFFICIAL-gts210wifi'
Build fingerprint: 'samsung/gts210wifixx/gts210wifi:7.0/NRD90M/T810XXU2DRB1:user/release-keys'
Revision: '0'
ABI: 'arm'
Timestamp: 2021-07-22 22:55:26+0200
pid: 3590, tid: 3948, name: Thread-10  >>> system_server <<<
uid: 1000
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x69007f
    r0  00000009  r1  00000011  r2  00430000  r3  a44e9084
    r4  5fd31b6c  r5  7871b0b0  r6  0069006f  r7  a778f260
    r8  5fe7d44b  r9  5fe7d216  r10 5fd31af8  r11 5fe80010
    ip  00000000  sp  5fd31ad0  lr  7add54cf  pc  5fe96baa

backtrace:
      #00 pc 00056baa  /system/lib/android.hardware.gnss@1.0.so (android::hardware::gnss::V1_0::BsAGnssRilCallback::requestSetIdCb(unsigned int)+450) (BuildId: 30ee8b14270ae2b3ae675a7f9b4de136)
      #01 pc 0000e8dd  /system/vendor/lib/hw/android.hardware.gnss@1.0-impl.universal5433.so (android::hardware::gnss::V1_0::implementation::AGnssRil::requestSetId(unsigned int)+32) (BuildId: d0033c7cb8d0d1a2c99f977719d0d967)
      #02 pc 0000fb05  /system/vendor/lib/hw/gps.default.so (broadcom::GpsiClient::marshal_agps_ril_request_setid(broadcom::IpcIncomingMessage&)+160) (BuildId: fe39be024fc2f98450c8d2fc07cda956)
      #03 pc 000170c5  /system/vendor/lib/hw/gps.default.so (broadcom::IpcPipeTransportBase::OnSelect(int, bool, bool, bool, void*)+280) (BuildId: fe39be024fc2f98450c8d2fc07cda956)
      #04 pc 0001717d  /system/vendor/lib/hw/gps.default.so (non-virtual thunk to broadcom::IpcPipeTransportBase::OnSelect(int, bool, bool, bool, void*)+12) (BuildId: fe39be024fc2f98450c8d2fc07cda956)
      #05 pc 00017703  /system/vendor/lib/hw/gps.default.so (broadcom::SelectManager::ProcessEvent(broadcom::ISelectHandler&, int, bool, bool, bool, void*)+26) (BuildId: fe39be024fc2f98450c8d2fc07cda956)
      #06 pc 0001765f  /system/vendor/lib/hw/gps.default.so (broadcom::SelectManager::PerformOneWaitAndProcess()+422) (BuildId: fe39be024fc2f98450c8d2fc07cda956)
      #07 pc 0000dec3  /system/vendor/lib/hw/gps.default.so (broadcom::ipc_thread_proc(void*)+30) (BuildId: fe39be024fc2f98450c8d2fc07cda956)
      #08 pc 0000e019  /system/vendor/lib/hw/android.hardware.gnss@1.0-impl.universal5433.so (threadFunc(void*)+6) (BuildId: d0033c7cb8d0d1a2c99f977719d0d967)
      #09 pc 000a6b73  /apex/com.android.runtime/lib/bionic/libc.so (__pthread_start(void*)+20) (BuildId: 2f913c25dc2cb38e6710ab59b8e5fb5c)
      #10 pc 00060713  /apex/com.android.runtime/lib/bionic/libc.so (__start_thread+30) (BuildId: 2f913c25dc2cb38e6710ab59b8e5fb5c)

=== twrp rescue party log ===

Boot command: boot-recovery
Got arguments from boot message
Startup Commands:  '--prompt_and_wipe_data' '--reason=RescueParty'RescueParty